### PR TITLE
feat: Integrate GitHub Copilot Rubber Duck cross-model review (CE)

### DIFF
--- a/.squad/rubber-duck.yml
+++ b/.squad/rubber-duck.yml
@@ -1,0 +1,15 @@
+# Rubber Duck Squad Configuration — AgentCraftworks CE
+# Squad-level opt-out and tuning for GitHub Copilot Rubber Duck cross-model review.
+#
+# Reference: docs/RUBBER_DUCK_INTEGRATION.md (CE edition)
+
+# Master switch. Set to false to disable automatic Rubber Duck reviews.
+# On-demand reviews always remain available.
+enabled: true
+
+triggerCheckpoints:
+  afterPlan: true
+  afterComplexImpl: true
+  afterTestWrite: true
+
+maxCallsPerHour: 10

--- a/.squad/rubber-duck.yml
+++ b/.squad/rubber-duck.yml
@@ -3,8 +3,9 @@
 #
 # Reference: docs/RUBBER_DUCK_INTEGRATION.md (CE edition)
 
-# Master switch. Set to false to disable automatic Rubber Duck reviews.
-# On-demand reviews always remain available.
+# Squad-level preference. Coordinators/agents should consult this before requesting
+# Rubber Duck reviews; setting it to false means they should skip routine review prompts.
+# Manual/on-demand reviews can still be requested when appropriate.
 enabled: true
 
 triggerCheckpoints:

--- a/docs/RUBBER_DUCK_INTEGRATION.md
+++ b/docs/RUBBER_DUCK_INTEGRATION.md
@@ -45,9 +45,11 @@ In CE, Rubber Duck is available as a **manual on-demand** capability — you or 
 3. Select a Claude model in the model picker
 4. Ensure GPT-5.4 access is enabled on your account
 
-### Opt Into Rubber Duck in Your Repo
+### Declare Your Rubber Duck Preferences
 
-Add a `rubberDuck` block to `.agentcraftworks.yml`:
+You can document your Rubber Duck preferences in `.agentcraftworks.yml` using a `rubberDuck` block:
+
+> ⚠️ **CE Convention — not automatically enforced.** In Community Edition, no workflow or runtime reads this file automatically. It is a coordinator/agent convention: coordinators and agents operating in your repo should consult this block before deciding whether to request a Rubber Duck review. Pro/Enterprise enforces these keys at FSM checkpoints automatically.
 
 ```yaml
 rubberDuck:
@@ -57,7 +59,7 @@ rubberDuck:
     afterPlan: true
     afterComplexImpl: true
     afterTestWrite: true
-  maxCallsPerHour: 10
+  maxCallsPerHour: 10      # Coordinators/agents should respect this as a rate guideline
 ```
 
 ### Opt Out

--- a/docs/RUBBER_DUCK_INTEGRATION.md
+++ b/docs/RUBBER_DUCK_INTEGRATION.md
@@ -113,7 +113,7 @@ Agent: Revising plan to use per-service TTL jitter (300–600s random offset)
 
 ## Squad Coordinator Integration (CE)
 
-If you use the Squad pattern (`.squad/squad.agent.md`), add this Rubber Duck protocol to your coordinator:
+If you use the Squad pattern, create `.squad/squad.agent.md` for your coordinator instructions (if it does not already exist), then add this Rubber Duck protocol:
 
 ```markdown
 ## Rubber Duck Review Protocol

--- a/docs/RUBBER_DUCK_INTEGRATION.md
+++ b/docs/RUBBER_DUCK_INTEGRATION.md
@@ -1,0 +1,162 @@
+# Rubber Duck Integration — AgentCraftworks CE
+
+> **Date**: April 2026  
+> **Status**: CURRENT  
+> **Edition**: Community Edition (CE) — open-source (MIT)  
+> **Related**: [ENGAGEMENT_LEVELS.md (CE)](./architecture.md) · [GitHub Copilot Rubber Duck](https://github.blog/ai-and-ml/github-copilot/github-copilot-cli-combines-model-families-for-a-second-opinion/)
+
+---
+
+## What Is Rubber Duck?
+
+**GitHub Copilot Rubber Duck** (released April 6, 2026) adds a cross-model-family second opinion to your agent workflow. When your primary agent uses Claude, Rubber Duck runs on GPT-5.4 — catching what the primary agent misses at three key checkpoints:
+
+1. **After drafting a plan** — before execution begins
+2. **After a complex implementation** — when 3+ files are changed
+3. **After writing tests, before running them** — catching gaps before self-reinforcement
+
+Rubber Duck is available via `gh copilot` with `/experimental` mode enabled in GitHub Copilot CLI.
+
+---
+
+## CE vs. Pro/Enterprise
+
+| Capability | CE (MIT) | Pro/Enterprise |
+|-----------|---------|---------------|
+| On-demand Rubber Duck via CLI | ✅ | ✅ |
+| Peer-to-peer Rubber Duck guidance | ✅ (manual) | ✅ (automatic) |
+| `.agentcraftworks.yml` config schema | ✅ | ✅ |
+| Automatic FSM `RD_REVIEW` gate | ❌ | ✅ |
+| Rate Governor integration | ❌ | ✅ |
+| `.squad/rd-reviews/` audit trail | ✅ (manual) | ✅ (automatic) |
+| Squad coordinator checkpoint hooks | ✅ | ✅ |
+| Environment-aware checkpoint activation | ❌ | ✅ |
+
+In CE, Rubber Duck is available as a **manual on-demand** capability — you or your agents invoke it explicitly. Pro/Enterprise adds automatic activation at FSM checkpoints, Rate Governor integration, and environment-specific policies.
+
+---
+
+## Getting Started (CE)
+
+### Prerequisites
+
+1. Install [GitHub Copilot CLI](https://github.com/features/copilot/cli)
+2. Enable experimental mode: run `/experimental` in a Copilot CLI session
+3. Select a Claude model in the model picker
+4. Ensure GPT-5.4 access is enabled on your account
+
+### Opt Into Rubber Duck in Your Repo
+
+Add a `rubberDuck` block to `.agentcraftworks.yml`:
+
+```yaml
+rubberDuck:
+  enabled: true
+  minEngagementLevel: 3   # Level 3 = Peer Programmer and above
+  triggerCheckpoints:
+    afterPlan: true
+    afterComplexImpl: true
+    afterTestWrite: true
+  maxCallsPerHour: 10
+```
+
+### Opt Out
+
+To disable Rubber Duck for your repo:
+
+```yaml
+# .agentcraftworks.yml
+rubberDuck:
+  enabled: false
+```
+
+To disable for a specific squad:
+
+```yaml
+# .squad/rubber-duck.yml
+enabled: false
+```
+
+To skip for a specific task, tell your agent: `"skip rubber duck for this task"`.
+
+---
+
+## Using Rubber Duck in Peer-to-Peer Workflows
+
+In CE, you can manually invoke Rubber Duck at any point by asking your agent:
+
+- `"Rubber duck this plan before we start"`
+- `"Get a second opinion on this implementation"`
+- `"Review our test coverage with rubber duck before running"`
+
+The agent will invoke Rubber Duck via the Copilot CLI task infrastructure, surface the concerns, and reason over what to change.
+
+### Example — Plan Review
+
+```
+You: We're about to implement the new caching layer. Rubber duck the plan first.
+
+Agent: Invoking Rubber Duck on the caching plan...
+
+Rubber Duck found 2 concerns:
+  [HIGH] The cache invalidation strategy uses a single global TTL — 
+         items written by different services will expire simultaneously, 
+         causing a thundering herd when the TTL fires.
+  [LOW]  The plan doesn't address cache-aside vs. write-through strategy 
+         for the user profile endpoint.
+
+Agent: Revising plan to use per-service TTL jitter (300–600s random offset) 
+       and adopting cache-aside for user profiles. Proceeding with revised plan.
+```
+
+---
+
+## Squad Coordinator Integration (CE)
+
+If you use the Squad pattern (`.squad/squad.agent.md`), add this Rubber Duck protocol to your coordinator:
+
+```markdown
+## Rubber Duck Review Protocol
+
+Before transitioning from PLANNING to IMPLEMENTATION, check:
+- Is rubberDuck.enabled == true in .agentcraftworks.yml?
+- Is engagement_level >= 3?
+
+If both: invoke Rubber Duck with:
+  checkpoint: "post_plan"
+  context: [full plan summary]
+
+Record the review in: .squad/rd-reviews/{timestamp}-post-plan.md
+Document what changed and why (or explicitly why not).
+
+Repeat at post_impl (3+ file changes) and post_test (before test run).
+```
+
+### Persistent Review Trail
+
+Store all Rubber Duck reviews in `.squad/rd-reviews/` for audit and retrospective:
+
+```
+.squad/
+  rd-reviews/
+    2026-04-17T14-30-00-post-plan.md
+    2026-04-17T15-45-00-post-impl.md
+    2026-04-17T16-20-00-post-test.md
+  decisions.md
+  history.md
+```
+
+Each review file records:
+- Checkpoint type and timestamp
+- Context provided to Rubber Duck
+- Concerns raised (with severity)
+- Agent reasoning: what changed, what was kept, and why
+
+---
+
+## Related Documentation
+
+- [Full Rubber Duck Integration Guide](https://agentcraftworks.com/docs/rubber-duck) (Pro/Enterprise)
+- [GitHub Copilot Rubber Duck Blog Post](https://github.blog/ai-and-ml/github-copilot/github-copilot-cli-combines-model-families-for-a-second-opinion/)
+- [Engagement Levels](./architecture.md)
+- [Contributing to AgentCraftworks CE](../CONTRIBUTING.md)

--- a/docs/RUBBER_DUCK_INTEGRATION.md
+++ b/docs/RUBBER_DUCK_INTEGRATION.md
@@ -9,7 +9,9 @@
 
 ## What Is Rubber Duck?
 
-**GitHub Copilot Rubber Duck** (released April 6, 2026) adds a cross-model-family second opinion to your agent workflow. When your primary agent uses Claude, Rubber Duck runs on GPT-5.4 — catching what the primary agent misses at three key checkpoints:
+**GitHub Copilot Rubber Duck** adds a cross-model-family second opinion to your agent workflow. When your primary agent uses one model family (e.g., Claude), Rubber Duck runs on a different model family (e.g., GPT) — catching what the primary agent misses at three key checkpoints:
+
+> **As of April 2026**: The default cross-model pairing is Claude → GPT-5.4. Model versions and pairings may change as GitHub Copilot evolves.
 
 1. **After drafting a plan** — before execution begins
 2. **After a complex implementation** — when 3+ files are changed
@@ -43,7 +45,7 @@ In CE, Rubber Duck is available as a **manual on-demand** capability — you or 
 1. Install [GitHub Copilot CLI](https://github.com/features/copilot/cli)
 2. Enable experimental mode: run `/experimental` in a Copilot CLI session
 3. Select a Claude model in the model picker
-4. Ensure GPT-5.4 access is enabled on your account
+4. Ensure access to a secondary model family (e.g., GPT) is enabled on your account
 
 ### Declare Your Rubber Duck Preferences
 

--- a/docs/RUBBER_DUCK_INTEGRATION.md
+++ b/docs/RUBBER_DUCK_INTEGRATION.md
@@ -3,7 +3,7 @@
 > **Date**: April 2026  
 > **Status**: CURRENT  
 > **Edition**: Community Edition (CE) — open-source (MIT)  
-> **Related**: [ENGAGEMENT_LEVELS.md (CE)](./architecture.md) · [GitHub Copilot Rubber Duck](https://github.blog/ai-and-ml/github-copilot/github-copilot-cli-combines-model-families-for-a-second-opinion/)
+> **Related**: [architecture.md (CE)](./architecture.md) · [GitHub Copilot Rubber Duck](https://github.blog/ai-and-ml/github-copilot/github-copilot-cli-combines-model-families-for-a-second-opinion/)
 
 ---
 


### PR DESCRIPTION
## Summary

Adds GitHub Copilot **Rubber Duck** cross-model second-opinion review support to AgentCraftworks CE.

Rubber Duck uses a different AI family from the primary orchestrator (e.g., Claude → GPT-5.x) to catch plan flaws, edge cases, and test gaps at three key checkpoints before they become execution errors. This PR brings the CE community up to date with the core platform integration.

---

## What's in this PR

### Squad Opt-Out Template
- **`.squad/rubber-duck.yml`** — Drop-in squad-level config for enabling/disabling Rubber Duck and tuning checkpoints and rate limits

### Customer Guidance
- **`docs/RUBBER_DUCK_INTEGRATION.md`** — Open-source-friendly customer guide covering:
  - How Rubber Duck works in peer-to-peer and squad patterns
  - Default behavior by engagement level
  - Opt-out instructions (repo-level, squad-level, per-task)
  - Rate Governor considerations
  - FAQ

---

## Default Behavior

| Engagement Level | Rubber Duck |
|-----------------|-------------|
| 1–2 (Observer, Advisor) | ❌ OFF |
| 3+ (Peer Programmer, Squad) | ✅ ON |

---

## Opt-Out

```yaml
# .squad/rubber-duck.yml
enabled: false
```

---

## Related PRs
- AgentCraftworks core: https://github.com/AgentCraftworks/AgentCraftworks/pull/862
- AgentCraftworks-WebSite: https://github.com/AgentCraftworks/AgentCraftworks-WebSite/pull/198
