### PR TITLE
Update allowlist in CLA workflow

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -61,7 +61,7 @@ jobs:
           path-to-signatures: "signatures/version1/cla.json"
           path-to-document: "https://github.com/AgentCraftworks/AgentCraftworks-CE/blob/main/.github/CLA.md"
           branch: "cla-signatures"
-          allowlist: bot*,dependabot[bot],github-actions[bot],Jenp-AICraftWorks
+          allowlist: bot*,dependabot[bot],github-actions[bot],Jenp-AICraftWorks,Copilot,copilot-swe-agent[bot],jenperret
           create-file-commit-message: "chore: store CLA signatures"
           signed-commit-message: "chore: CLA signed by @$contributorName"
           custom-notsigned-prcomment: |


### PR DESCRIPTION
This pull request updates the CLA workflow configuration to expand the list of users and bots that are automatically allowed to bypass the CLA signing requirement.

CLA workflow configuration:

* Added `Copilot`, `copilot-swe-agent[bot]`, and `jenperret` to the `allowlist` in `.github/workflows/cla.yml`, enabling these users and bots to bypass the CLA signing process.