### PR TITLE
fix: remove unsupported ACW workflow trigger

### DIFF
--- a/.github/workflows/acw-pr-readiness.yml
+++ b/.github/workflows/acw-pr-readiness.yml
@@ -12,6 +12,10 @@ permissions:
   issues: write
   security-events: read
 
+concurrency:
+  group: acw-pr-readiness-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
 jobs:
   pr-readiness:
     uses: AgentCraftworks/.github/.github/workflows/acw-pr-readiness-reusable.yml@c73707373b824d682aa5f538f82e722cd58437c9


### PR DESCRIPTION
Fixes \ACW PR Readiness\ workflow parse failures by removing unsupported \pull_request_review_thread\ trigger.

This unblocks required checks:
- pr-readiness / required-human-approval
- pr-readiness / ghas-gate
- pr-readiness / dependency-review-gate
- pr-readiness / review-feedback-gate