### PR TITLE
docs: apply PR-214 review feedback for branch-policy consistency

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -544,26 +544,6 @@ Full tooling instructions: [`RecordingStudio/AGENTS.md`](RecordingStudio/AGENTS.
 8. Merge after approval and CI passes
 9. Delete feature branch and worktree
 
-## Branching and Promotion Policy (MANDATORY)
-
-Standard promotion flow for this repository:
-
-any branch -> `staging` -> `main`
-
-Rules:
-
-1. Never push directly to `main` or `staging`.
-2. Create a branch from `main` with any name.
-3. Merge to `staging` first for full integration testing.
-4. Promote to `main` only by PR from `staging`.
-5. PRs into `main` from non-`staging` branches are disallowed.
-
-Bootstrap assets for this policy:
-
-- A script to initialize and enforce the branch policy for new repositories
-- A PR guard workflow that blocks merges violating the branch policy
-- A new-repo template or checklist documenting how to apply this policy to fresh projects
-
 ## Documentation Standards — Futures vs Implemented
 
 **All strategy evaluations, forward-looking plans, roadmaps, and proposals MUST be:**

--- a/docs/NEW_REPO_BRANCH_POLICY_TEMPLATE.md
+++ b/docs/NEW_REPO_BRANCH_POLICY_TEMPLATE.md
@@ -2,11 +2,13 @@
 
 Use this template when initializing a new AgentCraftworks repository.
 
+> Keep this template aligned with the current standards in `AGENTS.md`. If org standards change, update this file in the same change.
+
 ## Standard Flow
 
 All repositories should follow:
 
-- any branch -> `staging`
+- feature/work branch -> `staging`
 - `staging` -> `main`
 
 Direct pushes to `staging` and `main` are not allowed.
@@ -42,7 +44,7 @@ gh api repos/<owner>/<repo>/environments --jq '.environments[].name'
 ## Required Guardrails
 
 - PRs into `main` must come from `staging`.
-- PRs into `staging` can come from **any branch** (no naming restriction).
+- PRs into `staging` should come from feature/work branches (for example: `feat/*`, `feature/*`, `fix/*`).
 - At least 1 PR approval required for both `staging` and `main`.
 - Conversation resolution required.
 - Force-push and deletion disabled on protected branches.
@@ -55,7 +57,7 @@ Add this to `AGENTS.md` when creating a new repo:
 ## Branching and Promotion Policy (MANDATORY)
 
 1. Never push directly to `main` or `staging`.
-2. Create a work branch from `main` with any name.
+2. Create a feature/work branch from `main` (for example: `feat/*`, `feature/*`, or `fix/*`).
 3. Merge your branch into `staging` first.
 4. Promote to production only by PR from `staging` into `main`.
 5. PRs into `main` from non-`staging` branches are not allowed.


### PR DESCRIPTION
## Summary
Applies actionable review feedback from #214 into a dedicated PR targeting staging.

### Changes
- Removes the manually added Branching and Promotion Policy section from the ORG-STANDARD-synced block in AGENTS.md.
- Updates docs/NEW_REPO_BRANCH_POLICY_TEMPLATE.md to explicitly keep policy text aligned with AGENTS.md standards and to use consistent feature/work branch wording.

## Notes
- I also prepared a fix for .github/workflows/cla.yml secret naming consistency (GH_CE_APP_ID/GH_CE_APP_PRIVATE_KEY), but this session token cannot push workflow-file edits due missing workflow scope. That change can be added once a token with workflow scope is available.